### PR TITLE
Cleaner method.

### DIFF
--- a/Classes/NSString+USStateMap.h
+++ b/Classes/NSString+USStateMap.h
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 
 @interface NSString (USStateMap)
++ (NSDictionary *) stateAbbreviationsMap;
 - (NSString*) stateAbbreviationFromFullName;
 - (NSString*) stateFullNameFromAbbreviation;
 @end

--- a/Classes/NSString+USStateMap.m
+++ b/Classes/NSString+USStateMap.m
@@ -8,29 +8,24 @@
 @implementation NSString (USStateMap)
 
 static NSDictionary *stateAbbreviationsMap = nil;
-- (NSDictionary *)stateAbbreviationsMap 
++ (NSDictionary *)stateAbbreviationsMap
 {
     if (stateAbbreviationsMap == nil) {
         NSString *plist = [[NSBundle mainBundle] pathForResource:@"USStateAbbreviations" ofType:@"plist"];
         stateAbbreviationsMap = [[NSDictionary alloc] initWithContentsOfFile:plist];
     }
+    
     return stateAbbreviationsMap;
 }
 
 - (NSString *)stateAbbreviationFromFullName 
 {
-    return [self.stateAbbreviationsMap objectForKey:self.uppercaseString];
+    return [[NSString stateAbbreviationsMap] objectForKey:self.uppercaseString];
 }
 
 - (NSString *)stateFullNameFromAbbreviation
 {
     NSString *upperAbbr = [self uppercaseString];
-    
-    for (NSString *abbreviation in [self.stateAbbreviationsMap allValues]) {
-        if ([abbreviation isEqualToString:upperAbbr]) {   
-	    return [[self.stateAbbreviationsMap objectForKey:upperAbbr] capitalizedString];
-	}
-    }
-    return nil;
+    return [[[NSString stateAbbreviationsMap] allKeysForObject:upperAbbr] lastObject];
 }
 @end

--- a/Classes/NSString+USStateMap.m
+++ b/Classes/NSString+USStateMap.m
@@ -26,6 +26,6 @@ static NSDictionary *stateAbbreviationsMap = nil;
 - (NSString *)stateFullNameFromAbbreviation
 {
     NSString *upperAbbr = [self uppercaseString];
-    return [[[NSString stateAbbreviationsMap] allKeysForObject:upperAbbr] lastObject];
+    return [[[[NSString stateAbbreviationsMap] allKeysForObject:upperAbbr] lastObject] capitalizedString];
 }
 @end


### PR DESCRIPTION
The previous imp of stateFullNameFromAbbreviation was incorrect, it returned nil for all values from what I could tell. This is much more straight forward, and should run faster.

I also made the getting the map a class method, for public access.
