### PR TITLE
Fixes stateFullNameFromAbbreviation method

### DIFF
--- a/Classes/NSString+USStateMap.m
+++ b/Classes/NSString+USStateMap.m
@@ -25,12 +25,12 @@ static NSDictionary *stateAbbreviationsMap = nil;
 - (NSString *)stateFullNameFromAbbreviation
 {
     NSString *upperAbbr = [self uppercaseString];
+    NSUInteger abbrIndex = [self.stateAbbreviationsMap.allValues
+                            indexOfObjectPassingTest:^BOOL(NSString *abbr, NSUInteger idx, BOOL *stop) {
+                                return [abbr isEqualToString:upperAbbr];
+                            }];
+    if (abbrIndex == NSNotFound) return nil;
     
-    for (NSString *abbreviation in [self.stateAbbreviationsMap allValues]) {
-        if ([abbreviation isEqualToString:upperAbbr]) {   
-	    return [[self.stateAbbreviationsMap objectForKey:upperAbbr] capitalizedString];
-	}
-    }
-    return nil;
+    return self.stateAbbreviationsMap.allKeys[abbrIndex];
 }
 @end


### PR DESCRIPTION
The method was incorrect.  Line 31 was attempting to search for the located value as a key for the dictionary.

Ex.  [@"HI" stateFullNameFromAbbreviation]:

Line 30: The loop finds "HI" in the values for the dictionary
Line 31: [self.stateAbbreviationsMap objectForKey:@"HI"] returns nil because the key is "Hawaii" and the value is "HI"
