### PR TITLE
Fixes bug in stateFullNameFromAbbreviation so that it returns the state full name

### DIFF
--- a/Classes/NSString+USStateMap.m
+++ b/Classes/NSString+USStateMap.m
@@ -14,6 +14,7 @@ static NSDictionary *stateAbbreviationsMap = nil;
         NSString *plist = [[NSBundle mainBundle] pathForResource:@"USStateAbbreviations" ofType:@"plist"];
         stateAbbreviationsMap = [[NSDictionary alloc] initWithContentsOfFile:plist];
     }
+
     return stateAbbreviationsMap;
 }
 
@@ -24,13 +25,8 @@ static NSDictionary *stateAbbreviationsMap = nil;
 
 - (NSString *)stateFullNameFromAbbreviation
 {
-    NSString *upperAbbr = [self uppercaseString];
-    
-    for (NSString *abbreviation in [self.stateAbbreviationsMap allValues]) {
-        if ([abbreviation isEqualToString:upperAbbr]) {   
-	    return [[self.stateAbbreviationsMap objectForKey:upperAbbr] capitalizedString];
-	}
-    }
-    return nil;
+    NSString *uppercaseAbbreviation = [self uppercaseString];
+
+    return [[[self.stateAbbreviationsMap allKeysForObject:uppercaseAbbreviation] lastObject] capitalizedString];
 }
 @end

--- a/USStateAbbreviations.podspec
+++ b/USStateAbbreviations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'USStateAbbreviations'
-  s.version      = '0.0.2'
+  s.version      = '0.0.3'
   s.summary      = 'A category and plist file that work together to provide standardized access to US territory name abbreviations.'
   s.homepage     = 'https://github.com/djibouti33/US-State-Abbreviations'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
`stateFullNameFromAbbreviation` was using the state abbreviation as a key into the `stateAbbreviationsMap` dictionary.  This always produces `nil` because the keys for the `stateAbbreviationsMap` dictionary are the full state names, not abbreviations.

This change fixes `stateFullNameFromAbbreviation` so that it returns the full state name that is mapped to the input state abbreviation.
